### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/etcd-example.js
+++ b/etcd-example.js
@@ -1,4 +1,5 @@
-var etcd = require("github.com/quilt/etcd");
+const {createDeployment, githubKeys, Machine} = require("@quilt/quilt");
+var etcd = require("./etcd.js");
 
 var nWorker = 3;
 

--- a/etcd.js
+++ b/etcd.js
@@ -1,3 +1,5 @@
+const {Container, Service, PortRange} = require("@quilt/quilt");
+
 function Etcd(n) {
     var refContainer = new Container("quay.io/coreos/etcd:v3.0.2");
     this.etcd = new Service("etcd", refContainer.replicate(n));

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./etcd.js"
+  "name": "@quilt/etcd",
+  "version": "0.0.1",
+  "main": "./etcd.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.